### PR TITLE
Fix method definition missing colon

### DIFF
--- a/models/issue.py
+++ b/models/issue.py
@@ -1,6 +1,6 @@
 import re
 
-def managle_listeners(body)
+def managle_listeners(body):
     start = "listeners: "
     for line in body.split("\n"):
         if line.startswith(start):


### PR DESCRIPTION
I was not able to start the server (Python 2.7.3) without adding the colon to the method definition
